### PR TITLE
Added 'Client-ID' label on Authorization header to match imgur's api …

### DIFF
--- a/dist/ng-imgur.js
+++ b/dist/ng-imgur.js
@@ -109,7 +109,7 @@
 
                 // Strip the image type from the base64 data.
                 var base64Data  = event.target.result.split(',')[1],
-                    headerModel = { Authorization: imgurOptions.API_KEY },
+                    headerModel = { Authorization: 'Client-ID ' + imgurOptions.API_KEY },
                     dataModel   = { image: base64Data };
 
                 // Issue the request to upload the image data.


### PR DESCRIPTION
…changes

The imgur API now requires a Client-ID label before the client ID. 

Authorization: Client-ID YOUR_CLIENT_ID

I have added that label to prevent the user from getting a status 403 malformed auth header error when uploading an image.